### PR TITLE
Validated implementation of the AWS Load Balancer Controller and docu…

### DIFF
--- a/docs/addons/aws-load-balancer-controller.md
+++ b/docs/addons/aws-load-balancer-controller.md
@@ -1,0 +1,61 @@
+# AWS Load Balancer Controller Add-on
+The AWS Load Balancer Controller manages AWS Elastic Load Balancers for a Kubernetes cluster. The controller provisions the following resources:
+
+- An AWS Application Load Balancer (ALB) when you create a Kubernetes Ingress.
+
+- An AWS Network Load Balancer (NLB) when you create a Kubernetes Service of type LoadBalancer. In the past, you used the Kubernetes in-tree load balancer for instance targets, but used the AWS Load balancer Controller for IP targets. With the AWS Load Balancer Controller version 2.2.0 or later, you can create Network Load Balancers using either target type. For more information about NLB target types, see [Target type](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html#target-type) in the User Guide for Network Load Balancers.
+
+For more information about AWS Load Balancer Controller please see the [official documentation](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html).
+
+This controller is a required for proper configuration of other ingress controllers such as NGINX.
+
+## Usage
+
+```typescript
+import { AwsLoadBalancerControllerAddon }  from '@shapirov/cdk-eks-blueprint';
+
+readonly awsLoadBalancerController = new AwsLoadBalancerControllerAddon({version: '2.2.0'});// optionally specify image version to pull  or empty constructor
+const addOns: Array<ClusterAddOn> = [ awsLoadBalancerController ];
+
+const app = new cdk.App();
+new EksBlueprint(app, 'my-stack-name', addOns, [], {
+  env: {
+      account: <AWS_ACCOUNT_ID>,
+      region: <AWS_REGION>,
+  },
+});
+```
+To validate that controller is running ensure that controller deployment is in `RUNNING` state:
+
+```bash
+# Assuming controller is installed in kube-system namespace
+$ kubectl get deployments -n kube-system
+NAME                                                       READY   UP-TO-DATE   AVAILABLE   AGE
+aws-load-balancer-controller                               2/2     2            2           3m58s
+```
+You can now provision NLB and ALB load balancers. For example to provision an NLB you can use the following service manifest:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: '60'
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  name: udp-test1
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 5005
+    protocol: UDP
+    targetPort: 5005
+  selector:
+    name: your-app
+```
+
+## Functionality
+
+1. Adds proper IAM permissions and creates a Kubernetes service account with IRSA integration. 
+2. Allows configuration options such as enabling WAF and Shield. 
+3. Allows to replace the helm chart version if a specific version of the controller is needed.
+

--- a/docs/addons/cluster-autoscaler.md
+++ b/docs/addons/cluster-autoscaler.md
@@ -3,9 +3,9 @@
 ## Usage
 
 ```typescript
-import { ClusterAutoScaler }  from '@shapirov/cdk-eks-blueprint';
+import { ClusterAutoScalerAddOn }  from '@shapirov/cdk-eks-blueprint';
 
-readonly myClusterAutoscaler = new ClusterAutoscaler("v1.19.1");// optionally specify image version to pull  or empty constructor
+readonly myClusterAutoscaler = new ClusterAutoscalerAddOn("v1.19.1");// optionally specify image version to pull  or empty constructor
 const addOns: Array<ClusterAddOn> = [ myClusterAutoscaler ];
 
 const app = new cdk.App();

--- a/examples/multi-team-construct/index.ts
+++ b/examples/multi-team-construct/index.ts
@@ -30,7 +30,7 @@ export default class MultiTeamConstruct extends cdk.Construct {
             new ssp.MetricsServerAddOn,
             new ssp.ClusterAutoScalerAddOn,
             new ssp.ContainerInsightsAddOn,
-            new ssp.AwsLoadBalancerControllerAddOn({enableWaf: false})
+            new ssp.AwsLoadBalancerControllerAddOn()
         ];
 
         const stackID = `${id}-blueprint`

--- a/examples/multi-team-construct/index.ts
+++ b/examples/multi-team-construct/index.ts
@@ -30,6 +30,7 @@ export default class MultiTeamConstruct extends cdk.Construct {
             new ssp.MetricsServerAddOn,
             new ssp.ClusterAutoScalerAddOn,
             new ssp.ContainerInsightsAddOn,
+            new ssp.AwsLoadBalancerControllerAddOn({enableWaf: false})
         ];
 
         const stackID = `${id}-blueprint`

--- a/examples/pipeline-stack/index.ts
+++ b/examples/pipeline-stack/index.ts
@@ -10,7 +10,7 @@ import * as ssp from '../../lib'
 import * as team from '../teams'
 
 export default class PipelineStack extends cdk.Stack {
-    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    constructor(scope: cdk.App, id: string, _props?: cdk.StackProps) {
         super(scope, id)
 
         const pipeline = this.buildPipeline(this)

--- a/lib/addons/aws-loadbalancer-controller/index.ts
+++ b/lib/addons/aws-loadbalancer-controller/index.ts
@@ -83,7 +83,7 @@ export class AwsLoadBalancerControllerAddOn implements ClusterAddOn {
             chart: AWS_LOAD_BALANCER_CONTROLLER,
             repository: 'https://aws.github.io/eks-charts',
             namespace: this.options.namespace,
-            release: 'aws-load-balancer-controller',
+            release: AWS_LOAD_BALANCER_CONTROLLER,
             version: this.options.chartVersion,
             wait: true,
             timeout: cdk.Duration.minutes(15),

--- a/lib/addons/aws-loadbalancer-controller/index.ts
+++ b/lib/addons/aws-loadbalancer-controller/index.ts
@@ -1,0 +1,96 @@
+import * as cdk from "@aws-cdk/core";
+import * as iam from "@aws-cdk/aws-iam";
+import { ClusterAddOn, ClusterInfo } from "../../stacks";
+import request from 'sync-request';
+
+/**
+ * Configuration options for AWS Load Balancer controller
+ */
+export interface AwsLoadBalancerControllerProps {
+    /**
+     * Namespace where controller will be installed
+     */
+    namespace?: string,
+    /**
+     * Version of the controller, i.e. v2.2.0 
+     */
+    version?: string,
+
+    /**
+     * Enable Shield (must be false for CN partition)
+     */
+    enableShield?: boolean,
+
+    /**
+     * Enable WAF (must be false for CN partition)
+     */
+    enableWaf: boolean,
+
+    /**
+     * Enable WAFV2 (must be false for CN partition)
+     */
+    enableWafv2?: boolean
+}
+
+/**
+ * Defaults options for load balancer controller.
+ */
+const AwsLoadBalancerControllerDefaults: AwsLoadBalancerControllerProps = {
+    namespace: 'kube-system',
+    version: 'v2.2.0',
+    enableShield: false,
+    enableWaf: false,
+    enableWafv2: false
+}
+
+const AWS_LOAD_BALANCER_CONTROLLER = 'aws-load-balancer-controller';
+
+export class AwsLoadBalancerControllerAddOn implements ClusterAddOn {
+
+    private options: AwsLoadBalancerControllerProps;
+
+    constructor(props?: AwsLoadBalancerControllerProps) {
+        this.options = { ...AwsLoadBalancerControllerDefaults, ...props ?? {}};
+    }
+
+    deploy(clusterInfo: ClusterInfo): void {
+
+        const cluster = clusterInfo.cluster; 
+        const awsControllerBaseResourceBaseUrl = `https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/${this.options.version}/docs`;
+        const awsControllerPolicyUrl = `${awsControllerBaseResourceBaseUrl}/install/iam_policy${cluster.stack.region.startsWith('cn-') ? '_cn' : ''}.json`;
+        
+        const serviceAccount = cluster.addServiceAccount('aws-load-balancer-controller', {
+            name: AWS_LOAD_BALANCER_CONTROLLER,
+            namespace: this.options.namespace,
+        });
+
+        const policyJson = request('GET', awsControllerPolicyUrl).getBody().toString();
+        
+        ((JSON.parse(policyJson)).Statement as []).forEach((statement) => {
+            serviceAccount.addToPrincipalPolicy(iam.PolicyStatement.fromJson(statement));
+        });
+
+        const awsLoadBalancerControllerChart = cluster.addHelmChart('AWSLoadBalancerController', {
+            chart: AWS_LOAD_BALANCER_CONTROLLER,
+            repository: 'https://aws.github.io/eks-charts',
+            namespace: this.options.namespace,
+            release: 'aws-load-balancer-controller',
+            version: '1.2.0', // mapping to v2.2.0
+            wait: true,
+            timeout: cdk.Duration.minutes(15),
+            values: {
+                clusterName: cluster.clusterName,
+                    serviceAccount: {
+                    create: false,
+                    name: serviceAccount.serviceAccountName,
+                },
+                // must disable waf features for aws-cn partition
+                enableShield: this.options.enableShield,
+                enableWaf: this.options.enableWaf,
+                enableWafv2: this.options.enableWafv2,
+            },
+        });
+        
+        awsLoadBalancerControllerChart.node.addDependency(serviceAccount);
+    }
+}

--- a/lib/addons/index.ts
+++ b/lib/addons/index.ts
@@ -1,5 +1,6 @@
 export { AppMeshAddOn } from './appmesh'
 export { ArgoCDAddOn } from './argocd'
+export { AwsLoadBalancerControllerAddOn} from './aws-loadbalancer-controller'
 export { CalicoAddOn } from './calico'
 export { ContainerInsightsAddOn } from './container-insights'
 export { ClusterAutoScalerAddOn } from './cluster-autoscaler'


### PR DESCRIPTION
Validated implementation of the AWS Load Balancer Controller and documentation. Minor fixes

*Issue #, if available:*: related to #70

*Description of changes:*

Adds AWS LB controller implementation and documentation. This is needed for proper NGINX architecture as well as many other use cases, including UDP ingress with NLB, other ingress controllers such as Kong, AWS Native ingress support with ALB. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
