### PR TITLE
Added postdeploy lifecycle hook (for addons)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.16]
+        node-version: [12.18]
 
     steps:
     - uses: actions/checkout@v2

--- a/lib/addons/argocd/index.ts
+++ b/lib/addons/argocd/index.ts
@@ -20,6 +20,7 @@ export class ArgoCDAddOn implements ClusterAddOn, ClusterPostDeploy {
     }
 
     postDeploy(clusterInfo: ClusterInfo, teams: Team[]): void {
-        console.log("TODO: Implement postDeploy for ArgoCD AddOn!", clusterInfo, teams);
+        //TODO: implement this method
+        console.log("postDeploy for ArgoCD AddOn!", clusterInfo, teams);
     }
 }

--- a/lib/addons/argocd/index.ts
+++ b/lib/addons/argocd/index.ts
@@ -1,6 +1,7 @@
-import { ClusterAddOn, ClusterInfo } from "../../stacks/cluster-types";
+import { ClusterAddOn, ClusterInfo, ClusterPostDeploy } from "../../stacks/cluster-types";
+import { Team } from "../../teams";
 
-export class ArgoCDAddOn implements ClusterAddOn {
+export class ArgoCDAddOn implements ClusterAddOn, ClusterPostDeploy {
 
     readonly namespace: string;
 
@@ -16,5 +17,9 @@ export class ArgoCDAddOn implements ClusterAddOn {
             version: '3.2.3',
             namespace: this.namespace,
         });
+    }
+
+    postDeploy(clusterInfo: ClusterInfo, teams: Team[]): void {
+        console.log("TODO: Implement postDeploy for ArgoCD AddOn!", clusterInfo, teams);
     }
 }

--- a/lib/stacks/cluster-types.ts
+++ b/lib/stacks/cluster-types.ts
@@ -2,6 +2,7 @@ import * as cdk from '@aws-cdk/core';
 import { IVpc } from '@aws-cdk/aws-ec2';
 import { AutoScalingGroup } from '@aws-cdk/aws-autoscaling';
 import { Cluster, KubernetesVersion, Nodegroup } from '@aws-cdk/aws-eks';
+import { Team } from '../teams';
 
 /**
  * ClusterInfo describes an EKS cluster.
@@ -41,5 +42,14 @@ export interface ClusterProvider {
  */
 export interface ClusterAddOn {
     deploy(clusterInfo: ClusterInfo): void;
+}
+
+/**
+ * Optional interface to allow cluster bootstrapping after provisioning of add-ons and teams is complete.
+ * Can be leveraged to bootstrap workloads, perform cluster checks. 
+ * ClusterAddOn implementation may implement this interface in order to get post deployment hook point.
+ */
+export interface ClusterPostDeploy {
+    postDeploy(clusterInfo: ClusterInfo, teams: Team[]): void;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@shapirov/cdk-eks-blueprint",
-    "version": "0.10.2",
+    "version": "0.10.3",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {


### PR DESCRIPTION
*Issue #, if available:*
May need an issue (design bootstrap support)
*Description of changes:*

Added postDeploy lifecycle hook optionally implemented by Cluster AddOns.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
